### PR TITLE
Datatable

### DIFF
--- a/layouts/shortcodes/downloads.html
+++ b/layouts/shortcodes/downloads.html
@@ -1,5 +1,6 @@
 {{- $folder := .Get "folder" -}}
 {{- $boxTitle := .Get "boxTitle" -}}
+{{- $baseurl := .Site.BaseURL}}
 
 <section class="attachments blue">
 	<label>
@@ -9,7 +10,7 @@
 	<div class="attachments-files">
 	{{ range (readDir ( print "static/files/downloads/" $folder)) }}
 		<li>
-			<a href="{{ print "/files/downloads/" $folder "/" .Name }}">
+			<a href="{{ print $baseurl "files/downloads/" $folder "/" .Name }}">
 				{{.Name}}
 			</a>
 			({{div .Size 1024 }} {{T "BinaryPrefix-kilobyte"}})


### PR DESCRIPTION
Sample _index.md

{{< datatable file="files/json/test.json" prop="Metric n Property" >}}

Demo https://vinayvivekananda.github.io/vmware-operations-guide/demo/datatable/ 

Sample json, Json can have any number of rows and columns
```
{
    "Metric n Property": [
        {
            "Object": "VDI Pool",
            "Purpose": "Performance",
            "Type": "Metric",
            "Metric Group": "CPU",
            "Name": "% Sessions with CPU Queue",
            "Unit": "%",
            "Tool tips": "The portion of VDI Sessions, expressed in percentage, with CPU Queue Length > 2 per vCPU. This could indicate performance degradation"
        },
        {
            "Object": "VDI Pool",
            "Purpose": "Performance",
            "Type": "Metric",
            "Metric Group": "CPU",
            "Name": "% Sessions with CPU Ready",
            "Unit": "%",
            "Tool tips": "See \"% Session with CPU Queue Length\" for template/example. Follow it"
        }
   ]
}
```